### PR TITLE
Fetch posts based on journal mode

### DIFF
--- a/src/RoutesList.tsx
+++ b/src/RoutesList.tsx
@@ -18,7 +18,7 @@ const RoutesList = () => {
         throw new Error("AuthContext missing");
     }
 
-    const { currentUser, isAuthenticated, userInfoLoaded } = authContext;
+    const { isAuthenticated, userInfoLoaded } = authContext;
 
     // needed in order to render the layouts correctly.
     // read dev notes in context/AuthProvider
@@ -46,7 +46,7 @@ const RoutesList = () => {
                         !isAuthenticated ? (
                             <IndexPage />
                         ) : (
-                            <PostPage mode="teach" />
+                            <PostPage mode="teach" title="Journals awaiting your correction" />
                         )
                     }
                 />
@@ -61,11 +61,7 @@ const RoutesList = () => {
             <Route element={<LayoutWithContainer />}>
                 <Route
                     path="/journals"
-                    element={
-                        <PostPage
-                            mode={currentUser ? "teach" : "recentlyCorrected"}
-                        />
-                    }
+                    element={<PostPage mode="teach" title="Recently corrected journals" />}
                 />
                 <Route path="journals/:slug" element={<PostDetailPage />} />
             </Route>
@@ -74,8 +70,33 @@ const RoutesList = () => {
 
             <Route element={<RequireAuth />}>
                 <Route element={<LayoutWithContainer />}>
-                    <Route path="teach" element={<PostPage mode="teach" />} />
-                    <Route path="learn" element={<PostPage mode="learn" />} />
+                    <Route
+                        path="teach"
+                        element={
+                            <PostPage
+                                mode="teach"
+                                title="Journals awaiting your correction"
+                            />
+                        }
+                    />
+                    <Route
+                        path="learn"
+                        element={
+                            <PostPage
+                                mode="learn"
+                                title="Journals in the languages you’re studying"
+                            />
+                        }
+                    />
+                    <Route
+                        path="feed/following"
+                        element={
+                            <PostPage
+                                mode="following"
+                                title="Journals from your following"
+                            />
+                        }
+                    />
                     <Route path="create/post" element={<CreatePostPage />} />
                     <Route
                         path="journals/:slug/make-corrections"

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -34,20 +34,15 @@ export interface PostInterface {
     corrected_by: string[];
 }
 
-const SECTION_TITLE: { [key: string]: string } = {
-    teach: "Journals awaiting your correction",
-    learn: "Journals in the languages you’re studying",
-    recentlyCorrected: "Recently corrected journals",
-};
-
 interface IProps {
-    mode: string;
+    mode: "teach" | "learn" | "following";
+    title: string;
 }
 
-const PostPage = ({ mode }: IProps) => {
+const PostPage = ({ mode, title }: IProps) => {
     const { isLoading, isError, data } = useQuery({
-        queryKey: ["posts"],
-        queryFn: PostService.getPostList,
+        queryKey: ["posts", mode],
+        queryFn: () => PostService.getPostList(mode),
     });
 
     if (isError) return <h1>Problems loading...</h1>;
@@ -60,7 +55,7 @@ const PostPage = ({ mode }: IProps) => {
                 justifyContent="space-between"
                 mb={3}
             >
-                <Typography variant="h5">{SECTION_TITLE[mode]}</Typography>
+                <Typography variant="h5">{title}</Typography>
 
                 <Button
                     variant="contained"

--- a/src/service/post.service.tsx
+++ b/src/service/post.service.tsx
@@ -1,8 +1,9 @@
 import api from "./api";
 import { PostFormValues } from "../components/posts/PostForm";
 
-const getPostList = async () => {
-    const resp = await api.get(`/journals`);
+const getPostList = async (mode = "teach") => {
+    const params = { mode: mode };
+    const resp = await api.get(`/journals`, { params });
     return resp?.data?.results;
 };
 


### PR DESCRIPTION
This PR adds functionality to fetch entries based on the current journal mode. It would be nice to refactor all of these routes into a single route like `/feed`. However, doing so will cause issues with all of the indexed posts and pages on various search engines like Google. I have not added this change to this PR until more research is done.