### PR TITLE
66 notifications

### DIFF
--- a/src/components/TruncateText.tsx
+++ b/src/components/TruncateText.tsx
@@ -1,0 +1,23 @@
+import { Typography } from "@mui/material";
+
+interface Props {
+    text: string;
+}
+
+const styles = {
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+};
+
+const TruncateText = ({ text }: Props) => {
+    return (
+        <Typography component="span" sx={styles}>
+            {text}
+        </Typography>
+    );
+};
+
+export default TruncateText;

--- a/src/layouts/header/NotificationsPopover.tsx
+++ b/src/layouts/header/NotificationsPopover.tsx
@@ -4,11 +4,13 @@ import {
     Divider,
     IconButton,
     List,
+    ListItem,
     ListItemAvatar,
     ListItemButton,
     ListItemText,
     Popover,
     Stack,
+    Tooltip,
     Typography,
     useTheme,
 } from "@mui/material";
@@ -50,6 +52,15 @@ const NotificationsPopover = () => {
                 queryKey: ["notifications"],
             }),
         onError: () => console.log("Error marking notification as read"),
+    });
+
+    const clearAllNotificationsMutation = useMutation({
+        mutationFn: NotificationService.clearAllNotifications,
+        onSuccess: () =>
+            queryClient.invalidateQueries({
+                queryKey: ["notifications"],
+            }),
+        onError: () => console.log("Error clearing all notifications"),
     });
 
     const handleOpen = (evt: React.MouseEvent<HTMLButtonElement>) => {
@@ -102,8 +113,14 @@ const NotificationsPopover = () => {
                     <Typography sx={{ padding: 1, fontWeight: 700 }}>
                         Notifications
                     </Typography>
-                    <IconButton sx={{ padding: 1 }}>
-                        <DeleteOutlineIcon />
+                    <IconButton
+                        sx={{ padding: 1 }}
+                        onClick={() => clearAllNotificationsMutation.mutate()}
+                        disabled={data?.unread_count === 0 ? true : false}
+                    >
+                        <Tooltip title="Clear all notifications" arrow>
+                            <DeleteOutlineIcon />
+                        </Tooltip>
                     </IconButton>
                 </Stack>
                 <List
@@ -143,6 +160,13 @@ const NotificationsPopover = () => {
                             />
                         </ListItemButton>
                     ))}
+                    {data?.unread_count === 0 && (
+                        <ListItem>
+                            <ListItemText>
+                                You have no notifications.
+                            </ListItemText>
+                        </ListItem>
+                    )}
                 </List>
             </Popover>
         </>

--- a/src/layouts/header/NotificationsPopover.tsx
+++ b/src/layouts/header/NotificationsPopover.tsx
@@ -22,8 +22,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import NotificationService from "../../service/notification.service";
 import TruncateText from "../../components/TruncateText";
 import { useNavigate } from "react-router-dom";
-import { Notification as INotification } from "../../types";
+import { Notification as INotification, NotificationTypes } from "../../types";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import PersonAddAltIcon from "@mui/icons-material/PersonAddAlt";
 
 const NotificationsPopover = () => {
     const theme = useTheme();
@@ -148,17 +149,22 @@ const NotificationsPopover = () => {
                         >
                             <ListItemAvatar>
                                 <Avatar>
-                                    {/* TODO: Refactor this to include other notification types */}
                                     {notification.description ===
-                                    "new_correction" ? (
-                                        <CheckCircleOutlineIcon />
-                                    ) : (
+                                    NotificationTypes.Post ? (
                                         <CreateIcon />
+                                    ) : notification.description ===
+                                      NotificationTypes.Correction ? (
+                                        <CheckCircleOutlineIcon />
+                                    ) : notification.description ===
+                                      NotificationTypes.Follow ? (
+                                        <PersonAddAltIcon />
+                                    ) : (
+                                        ""
                                     )}
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText
-                                primary={`${notification.actor}${notification.verb}`}
+                                primary={`${notification.actor} ${notification.verb}`}
                                 secondary={
                                     <TruncateText
                                         text={notification.action_object}

--- a/src/layouts/header/NotificationsPopover.tsx
+++ b/src/layouts/header/NotificationsPopover.tsx
@@ -23,6 +23,7 @@ import NotificationService from "../../service/notification.service";
 import TruncateText from "../../components/TruncateText";
 import { useNavigate } from "react-router-dom";
 import { Notification as INotification } from "../../types";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 
 const NotificationsPopover = () => {
     const theme = useTheme();
@@ -147,7 +148,13 @@ const NotificationsPopover = () => {
                         >
                             <ListItemAvatar>
                                 <Avatar>
-                                    <CreateIcon />
+                                    {/* TODO: Refactor this to include other notification types */}
+                                    {notification.description ===
+                                    "new_correction" ? (
+                                        <CheckCircleOutlineIcon />
+                                    ) : (
+                                        <CreateIcon />
+                                    )}
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText

--- a/src/service/notification.service.tsx
+++ b/src/service/notification.service.tsx
@@ -10,9 +10,15 @@ const markNotificationRead = async (slug: number) => {
     return resp?.data;
 };
 
+const clearAllNotifications = async () => {
+    const resp = await api.get(`notifications/clear`);
+    return resp?.data;
+};
+
 const NotificationService = {
     getNotifications,
     markNotificationRead,
+    clearAllNotifications,
 };
 
 export default NotificationService;

--- a/src/service/notification.service.tsx
+++ b/src/service/notification.service.tsx
@@ -1,0 +1,18 @@
+import api from "./api";
+
+const getNotifications = async () => {
+    const resp = await api.get(`notifications/unread`);
+    return resp?.data;
+};
+
+const markNotificationRead = async (slug: number) => {
+    const resp = await api.get(`notifications/read/${slug}`);
+    return resp?.data;
+};
+
+const NotificationService = {
+    getNotifications,
+    markNotificationRead,
+};
+
+export default NotificationService;

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,7 @@ export interface Correction {
 export type CorrectionFormValues = {
     correction?: string;
     note?: string;
-}
+};
 
 export interface CorrectionRow {
     postrow_id: number;
@@ -117,7 +117,7 @@ export interface OverallFeedback {
     username?: string;
 }
 
-export interface Comment{
+export interface Comment {
     id: string;
     username: string;
     text: string;
@@ -129,7 +129,6 @@ export interface UserCorrection {
     comments: Comment[];
     overall_feedback: OverallFeedback[];
 }
-
 
 export interface User {
     id: number;
@@ -153,4 +152,15 @@ export type UserRegisterFormValues = {
     studying_language: string;
     studying_level: string;
     gender: string;
+};
+
+export interface Notification {
+    id: number;
+    verb: string;
+    description: string;
+    timestamp: Date;
+    slug: number;
+    action_object: string;
+    actor: string;
+    obj_slug: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,3 +164,13 @@ export interface Notification {
     actor: string;
     obj_slug: string;
 }
+
+export enum NotificationTypes {
+    Post = "new_post",
+    Correction = "new_correction",
+    Follow = "new_follower",
+    // Comment = "new_comment",
+    // Reply = "new_reply"
+    // Like = "new_like",
+    // Deletion = "new_deletion"
+}


### PR DESCRIPTION
closes #66

Adds a notification system that currently supports the following notification types:
- `new_post`
- `new_correction`
- `new_follower`

The following notification types will be supported at a later date:
- `new_deletion`
- `new_comments`
- `new_reply`
- `new_like`

The notification system will now only show **unread** notifications instead of unread and read notifications.